### PR TITLE
Fixes "wrong number of arguments (3 for 2) (ArgumentError)" error

### DIFF
--- a/app/helpers/admin/form_datas_helper.rb
+++ b/app/helpers/admin/form_datas_helper.rb
@@ -29,7 +29,7 @@ module Admin::FormDatasHelper
   end
   
   def date_format(timestamp)
-    timestamp && timestamp.to_date.to_s(:rfc822)
+    timestamp && l(timestamp, :format => :long)
   end
   
   def filters_present(&block)

--- a/app/models/form_data.rb
+++ b/app/models/form_data.rb
@@ -30,7 +30,7 @@ class FormData < ActiveRecord::Base
   end
   
   def self.find_all_group_by_url
-     find(:all, :group => 'url')
+     find(:all, :group => 'url', :select => 'url')
   end
   
   def self.find_for_export(params, export_all)

--- a/database_mailer_extension.rb
+++ b/database_mailer_extension.rb
@@ -12,18 +12,20 @@ class DatabaseMailerExtension < Radiant::Extension
       end
     end
   end
-  
+
   def activate
     throw "MailerExtension must be loaded before DatabaseMailerExtension" unless defined?(MailerExtension)
     MailController.class_eval do
       include DatabaseMailerProcessing
       alias_method_chain :process_mail, :database
     end
-    admin.nav["content"] << admin.nav_item(:database_mailer, "Database Mailer", "/admin/form_datas")
-        
+    tab "Content" do
+      add_item "Database Mailer", "/admin/form_datas"
+    end
+
     Mime::Type.register "application/vnd.ms-excel", :xls
   end
-  
+
   def deactivate
   end
 end


### PR DESCRIPTION
Trace:

/opt/ruby-enterprise-1.8.7-2009.10/lib/ruby/gems/1.8/gems/radiant-0.9.1/lib/radiant/admin_ui.rb:115:in `initialize': wrong number of arguments (3 for 2) (ArgumentError)
    from /opt/ruby-enterprise-1.8.7-2009.10/lib/ruby/gems/1.8/gems/radiant-0.9.1/lib/radiant/admin_ui.rb:115:in`new'
    from /opt/ruby-enterprise-1.8.7-2009.10/lib/ruby/gems/1.8/gems/radiant-0.9.1/lib/radiant/admin_ui.rb:115:in `nav_item'
    from /Users/boss/Sites/manhattan/vendor/extensions/database_mailer/database_mailer_extension.rb:22:in`activate'
    from /opt/ruby-enterprise-1.8.7-2009.10/lib/ruby/gems/1.8/gems/radiant-0.9.1/lib/radiant/extension.rb:86:in `activate'
    from /opt/ruby-enterprise-1.8.7-2009.10/lib/ruby/1.8/ostruct.rb:83:in`to_proc'
    from /opt/ruby-enterprise-1.8.7-2009.10/lib/ruby/gems/1.8/gems/radiant-0.9.1/lib/radiant/extension_loader.rb:106:in `each'
    from /opt/ruby-enterprise-1.8.7-2009.10/lib/ruby/gems/1.8/gems/radiant-0.9.1/lib/radiant/extension_loader.rb:106:in`activate_extensions'
    from /opt/ruby-enterprise-1.8.7-2009.10/lib/ruby/gems/1.8/gems/radiant-0.9.1/lib/radiant/initializer.rb:201:in `after_initialize'
    from /opt/ruby-enterprise-1.8.7-2009.10/lib/ruby/gems/1.8/gems/radiant-0.9.1/vendor/rails/railties/lib/initializer.rb:179:in`process'
    from /opt/ruby-enterprise-1.8.7-2009.10/lib/ruby/gems/1.8/gems/radiant-0.9.1/vendor/rails/railties/lib/initializer.rb:113:in `send'
    from /opt/ruby-enterprise-1.8.7-2009.10/lib/ruby/gems/1.8/gems/radiant-0.9.1/vendor/rails/railties/lib/initializer.rb:113:in`run'
    from /opt/ruby-enterprise-1.8.7-2009.10/lib/ruby/gems/1.8/gems/radiant-0.9.1/lib/radiant/initializer.rb:157:in `run'
    from /Users/boss/Sites/manhattan/config/environment.rb:12
    from /opt/ruby-enterprise-1.8.7-2009.10/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:31:in`gem_original_require'
    from /opt/ruby-enterprise-1.8.7-2009.10/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:31:in `require'
    from /opt/ruby-enterprise-1.8.7-2009.10/lib/ruby/gems/1.8/gems/radiant-0.9.1/vendor/rails/activesupport/lib/active_support/dependencies.rb:156:in`require'
    from /opt/ruby-enterprise-1.8.7-2009.10/lib/ruby/gems/1.8/gems/radiant-0.9.1/vendor/rails/activesupport/lib/active_support/dependencies.rb:521:in `new_constants_in'
    from /opt/ruby-enterprise-1.8.7-2009.10/lib/ruby/gems/1.8/gems/radiant-0.9.1/vendor/rails/activesupport/lib/active_support/dependencies.rb:156:in`require'
    from /opt/ruby-enterprise-1.8.7-2009.10/lib/ruby/gems/1.8/gems/radiant-0.9.1/vendor/rails/railties/lib/commands/server.rb:84
    from /opt/ruby-enterprise-1.8.7-2009.10/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:31:in `gem_original_require'
    from /opt/ruby-enterprise-1.8.7-2009.10/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:31:in`require'
    from script/server:3
