### PR TITLE
Fixes FormData.find_all_group_by_url

### DIFF
--- a/app/helpers/admin/form_datas_helper.rb
+++ b/app/helpers/admin/form_datas_helper.rb
@@ -29,7 +29,7 @@ module Admin::FormDatasHelper
   end
   
   def date_format(timestamp)
-    timestamp && timestamp.to_date.to_s(:rfc822)
+    timestamp && l(timestamp, :format => :long)
   end
   
   def filters_present(&block)

--- a/app/models/form_data.rb
+++ b/app/models/form_data.rb
@@ -30,7 +30,7 @@ class FormData < ActiveRecord::Base
   end
   
   def self.find_all_group_by_url
-     find(:all, :group => 'url')
+     find(:all, :group => 'url', :select => 'url')
   end
   
   def self.find_for_export(params, export_all)

--- a/database_mailer_extension.rb
+++ b/database_mailer_extension.rb
@@ -12,18 +12,20 @@ class DatabaseMailerExtension < Radiant::Extension
       end
     end
   end
-  
+
   def activate
     throw "MailerExtension must be loaded before DatabaseMailerExtension" unless defined?(MailerExtension)
     MailController.class_eval do
       include DatabaseMailerProcessing
       alias_method_chain :process_mail, :database
     end
-    admin.nav["content"] << admin.nav_item(:database_mailer, "Database Mailer", "/admin/form_datas")
-        
+    tab "Content" do
+      add_item "Database Mailer", "/admin/form_datas"
+    end
+
     Mime::Type.register "application/vnd.ms-excel", :xls
   end
-  
+
   def deactivate
   end
 end


### PR DESCRIPTION
Postgres failed on this SQL:
SELECT \* FROM "form_datas" GROUP BY id;
while it can not use \* with GROUP BY. Fixed changing

find(:all, :group => 'url')
to
find(:all, :group => 'url', :select => 'url')
