### PR TITLE
Fixed 'undefined method has_attached_file for' error

### DIFF
--- a/app/controllers/database_mailer_processing.rb
+++ b/app/controllers/database_mailer_processing.rb
@@ -4,7 +4,7 @@ module DatabaseMailerProcessing
     page = mail.page
     plain_body = (page.part( :email ) ? page.render_part( :email ) : page.render_part( :email_plain ))
     
-    if config[:save_to_database] || config[:save_to_database].nil?
+    if mail.valid? && (config[:save_to_database] || config[:save_to_database].nil?)
       fd = FormData.create(mail.data.merge(:url => mail.page.url, :blob => plain_body))    
       mail.data.each do |k, v|
         if v.class.to_s == "Tempfile"

--- a/app/helpers/admin/form_datas_helper.rb
+++ b/app/helpers/admin/form_datas_helper.rb
@@ -29,7 +29,7 @@ module Admin::FormDatasHelper
   end
   
   def date_format(timestamp)
-    timestamp && timestamp.to_date.to_s(:rfc822)
+    timestamp && l(timestamp, :format => :long)
   end
   
   def filters_present(&block)

--- a/app/models/form_data.rb
+++ b/app/models/form_data.rb
@@ -30,7 +30,7 @@ class FormData < ActiveRecord::Base
   end
   
   def self.find_all_group_by_url
-     find(:all, :group => 'url')
+     find(:all, :group => 'url', :select => 'url')
   end
   
   def self.find_for_export(params, export_all)

--- a/app/models/form_data_asset.rb
+++ b/app/models/form_data_asset.rb
@@ -1,3 +1,5 @@
+require 'paperclip'
+
 class FormDataAsset < ActiveRecord::Base
   belongs_to :form_data
   

--- a/database_mailer_extension.rb
+++ b/database_mailer_extension.rb
@@ -12,18 +12,20 @@ class DatabaseMailerExtension < Radiant::Extension
       end
     end
   end
-  
+
   def activate
     throw "MailerExtension must be loaded before DatabaseMailerExtension" unless defined?(MailerExtension)
     MailController.class_eval do
       include DatabaseMailerProcessing
       alias_method_chain :process_mail, :database
     end
-    admin.nav["content"] << admin.nav_item(:database_mailer, "Database Mailer", "/admin/form_datas")
-        
+    tab "Content" do
+      add_item "Database Mailer", "/admin/form_datas"
+    end
+
     Mime::Type.register "application/vnd.ms-excel", :xls
   end
-  
+
   def deactivate
   end
 end


### PR DESCRIPTION
When you click "Show" on a row in the Database Mailer subtab, Rails threw an error that read, "undefined method 'has_attached_file' for ..." I required paperclip above the FormDataAsset class, and this fixed the error.

Note that I incorporated divineforest's changes into my bug fix branch. He submitted a pull request for these changes already.
